### PR TITLE
Fix: Workflows

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -1,4 +1,4 @@
-name: Publish New Package Versions
+name: Publish New API Package Version
 on:
   push:
     branches: [main]

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: ../../api/package.json
+          package: ./api/package.json

--- a/.github/workflows/sensor-scatterplot-release.yml
+++ b/.github/workflows/sensor-scatterplot-release.yml
@@ -1,4 +1,4 @@
-name: Publish New Package Versions
+name: Publish New Sensor Scatterplot Package Version
 on:
   push:
     branches: [main]

--- a/.github/workflows/sensor-scatterplot-release.yml
+++ b/.github/workflows/sensor-scatterplot-release.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: ../../web-components/sensor-scatterplot/package.json
+          package: ./web-components/sensor-scatterplot/package.json

--- a/.github/workflows/types-release.yml
+++ b/.github/workflows/types-release.yml
@@ -1,4 +1,4 @@
-name: Publish New Package Versions
+name: Publish New Types Package Version
 on:
   push:
     branches: [main]

--- a/.github/workflows/types-release.yml
+++ b/.github/workflows/types-release.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: ../../types/package.json
+          package: ./types/package.json


### PR DESCRIPTION
Workflows previously failed when the package variable was set to the grandparent directory. The package variable has be changed to the current working directory, and package names have been added into each workflow's name