### PR TITLE
Fix: Workflows

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -13,5 +13,6 @@ jobs:
       - run: npm ci
       - uses: JS-DevTools/npm-publish@v2
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          access: public
           package: ./api/package.json
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sensor-scatterplot-release.yml
+++ b/.github/workflows/sensor-scatterplot-release.yml
@@ -13,5 +13,6 @@ jobs:
       - run: npm ci
       - uses: JS-DevTools/npm-publish@v2
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          access: public
           package: ./web-components/sensor-scatterplot/package.json
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/types-release.yml
+++ b/.github/workflows/types-release.yml
@@ -13,5 +13,6 @@ jobs:
       - run: npm ci
       - uses: JS-DevTools/npm-publish@v2
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          access: public
           package: ./types/package.json
+          token: ${{ secrets.NPM_TOKEN }}

--- a/web-components/sensor-scatterplot/package.json
+++ b/web-components/sensor-scatterplot/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@sjvair/sensor-scatterplot",
-  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Workflows previously failed when the publish access type is not set; the access variable in workflows has been set to "public"