### PR TITLE
Fix: ScatterPlot Constructor

### DIFF
--- a/web-components/sensor-scatterplot/package.json
+++ b/web-components/sensor-scatterplot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sjvair/sensor-scatterplot",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "files": [ "dist", "src" ],
   "scripts": {

--- a/web-components/sensor-scatterplot/src/main.ts
+++ b/web-components/sensor-scatterplot/src/main.ts
@@ -39,14 +39,8 @@ export class ScatterPlot extends BaseElement {
   get template() {
     return `<div id="chartContainer"></div>`;
   }
-  
-  /**
-   * Creates a new ScatterPlot element
-   *
-   * @returns A new instances of ScatterPlot
-   */
-  constructor() {
-    super();
+
+  protected onConnected() {
     this.style.display = "block";
   }
 


### PR DESCRIPTION
Moves constructor logic to `onConnected` hook